### PR TITLE
Centralize EF Core Sqlite package version

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -52,6 +52,7 @@
     <PackageVersion Include="Mapster" Version="7.4.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.2" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.6.0.109712" />

--- a/src/api/server/Server.csproj
+++ b/src/api/server/Server.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Twilio" Version="6.6.2" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- centralize Microsoft.EntityFrameworkCore.Sqlite package in `Directory.Packages.props`
- rely on central version in `Server.csproj`

## Testing
- `dotnet build src/api/server/Server.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1aa14983c83318293d186754106dd