### PR TITLE
Centralize Twilio package version

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -47,6 +47,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.12.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.12.0" />
+    <PackageVersion Include="Twilio" Version="6.6.2" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Mapster" Version="7.4.0" />

--- a/src/api/server/Server.csproj
+++ b/src/api/server/Server.csproj
@@ -16,8 +16,8 @@
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
-    <PackageReference Include="Twilio" Version="6.6.2" />
-  </ItemGroup>
+      <PackageReference Include="Twilio" />
+    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\framework\Core\Core.csproj" />
     <ProjectReference Include="..\framework\Infrastructure\Infrastructure.csproj" />


### PR DESCRIPTION
## Summary
- centralize Twilio NuGet version in Directory.Packages.props
- rely on central version for Twilio in Server.csproj

## Testing
- `dotnet restore src/FSH.Starter.sln` *(fails: command not found)*
- `curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh` *(fails: CONNECT tunnel 403)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a1aa0f9174833188bb287ff7d8eedd