### PR TITLE
Add API namespace import to server program

### DIFF
--- a/src/api/server/Program.cs
+++ b/src/api/server/Program.cs
@@ -1,3 +1,4 @@
+using FSH.Starter.Api;
 using FSH.Starter.Api.Data;
 using FSH.Starter.Api.Services;
 using Microsoft.EntityFrameworkCore;


### PR DESCRIPTION
## Summary
- add missing using for `FSH.Starter.Api` in server `Program.cs`

## Testing
- `dotnet build src/FSH.Starter.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a1af79b2788331bd79a0e2f039243d